### PR TITLE
Updated props in components/Chess

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ Via npm:
 
     $ npm i redux-chess
 
-### Example
+### Examples
+
+Basic chessboard without server-side functionality:
+
+```js
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Chess } from 'redux-chess';
+
+const props = {};
+
+ReactDOM.render(
+  <Chess props={props} />,
+  document.getElementById('redux-chess')
+);
+```
+
+Chessboard with server-side functionality such as move validation and so on.
 
 ```js
 import React from 'react';
@@ -16,14 +33,17 @@ import ReactDOM from 'react-dom';
 import { Chess } from 'redux-chess';
 
 const props = {
-  host: '127.0.0.1',
-  port: '8080'
+  server: {
+    host: '127.0.0.1',
+    port: '8080'
+  }
 };
 
 ReactDOM.render(
   <Chess props={props} />,
   document.getElementById('redux-chess')
 );
+
 ```
 
 ![Redux Chess](/resources/demo.gif)

--- a/src/components/Board.js
+++ b/src/components/Board.js
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { analysis, connect, quit } from '../actions/serverActions';
-import { startBoard, pickPiece, leavePiece } from '../actions/boardActions';
-import History from './History';
+import { pickPiece, leavePiece } from '../actions/boardActions';
 import Pgn from '../utils/Pgn';
 import Piece from '../utils/Piece';
 
@@ -43,34 +41,8 @@ const Board = ({props}) => {
   }
 
   return (
-    <div>
-      <div className="game">
-        <div>
-          <button
-            disabled={state.server.ws && state.server.ws.readyState === WebSocket.OPEN}
-            onClick={() => {
-              dispatch(startBoard({ back: state.board.history.length - 1 }));
-              dispatch(connect(state.server.ws, props.host, props.port)).catch(e => {});
-          }}>
-            Connect
-          </button>
-
-          <button
-            onClick={() => {
-              dispatch(startBoard({ back: state.board.history.length - 1 }));
-              if (state.server.ws) {
-                dispatch(quit(state.server.ws)).then(() => {
-                  dispatch(analysis(state.server.ws));
-                });
-              }
-            }}>Analysis board</button>
-        </div>
-
-        <div className={['board', state.history.back !== 0 ? 'past' : 'present'].join(' ')}>
-          {board()}
-        </div>
-      </div>
-      <History />
+    <div className={['board', state.history.back !== 0 ? 'past' : 'present'].join(' ')}>
+      {board()}
     </div>
   );
 }

--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { analysis, connect, quit } from '../actions/serverActions';
+import { startBoard } from '../actions/boardActions';
+
+const Buttons = ({props}) => {
+  const state = useSelector(state => state);
+  const dispatch = useDispatch();
+
+  const buttons = () => {
+    let items = [];
+
+    if (props.server) {
+        items.push(<button
+          key={0}
+          disabled={state.server.ws && state.server.ws.readyState === WebSocket.OPEN}
+          onClick={() => {
+            dispatch(startBoard({ back: state.board.history.length - 1 }));
+            dispatch(connect(state.server.ws, props.server.host, props.server.port)).catch(e => {});
+          }}>
+          Connect
+        </button>);
+    }
+
+    items.push(<button
+      key={1}
+      onClick={() => {
+        dispatch(startBoard({ back: state.board.history.length - 1 }));
+        if (state.server.ws) {
+          dispatch(quit(state.server.ws)).then(() => dispatch(analysis(state.server.ws)))
+        }
+      }}>Analysis board
+    </button>);
+
+    return items;
+  }
+
+  return (
+    <div className="buttons">
+      {buttons()}
+    </div>
+  );
+}
+
+export default Buttons;

--- a/src/components/Chess.js
+++ b/src/components/Chess.js
@@ -1,15 +1,19 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import store from '../store';
+import Buttons from './Buttons.js';
 import Board from './Board.js';
+import History from './History';
 import MoveValidator from './MoveValidator.js';
 import '../index.css';
 
 const Chess = ({props}) => {
   return (
     <Provider store={store}>
+      <Buttons props={props} />
       <Board props={props} />
-      <MoveValidator />
+      <History />
+      {props.server ? <MoveValidator /> : null}
     </Provider>
   );
 }

--- a/src/components/History.js
+++ b/src/components/History.js
@@ -7,25 +7,23 @@ const History = () => {
   const dispatch = useDispatch();
 
   return (
-    <div>
-      <div className="browser">
-        <button
-          disabled={state.board.history.length - 1 - Math.abs(state.history.back) === 0}
-          onClick={() => dispatch(goToBeginning({ back: state.board.history.length - 1}))}>&lt;&lt;
-        </button>
-        <button
-          disabled={state.board.history.length - 1 - Math.abs(state.history.back) === 0}
-          onClick={() => dispatch(goBack())}>&lt;
-        </button>
-        <button
-          disabled={state.history.back === 0}
-          onClick={() => dispatch(goForward())}>&gt;
-        </button>
-        <button
-          disabled={state.history.back === 0}
-          onClick={() => dispatch(goToEnd())}>&gt;&gt;
-        </button>
-      </div>
+    <div className="history">
+      <button
+        disabled={state.board.history.length - 1 - Math.abs(state.history.back) === 0}
+        onClick={() => dispatch(goToBeginning({ back: state.board.history.length - 1}))}>&lt;&lt;
+      </button>
+      <button
+        disabled={state.board.history.length - 1 - Math.abs(state.history.back) === 0}
+        onClick={() => dispatch(goBack())}>&lt;
+      </button>
+      <button
+        disabled={state.history.back === 0}
+        onClick={() => dispatch(goForward())}>&gt;
+      </button>
+      <button
+        disabled={state.history.back === 0}
+        onClick={() => dispatch(goToEnd())}>&gt;&gt;
+      </button>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,14 +1,25 @@
 #redux-chess {
   display: flex;
+  flex-direction: column;
+  text-align: center;
   justify-content: center;
-  align-items: center;
 }
 
-.game .board {
+.buttons {
+  clear: both;
+}
+
+.board {
   font-family: FreeSerif, sans-serif;
   border: 1px solid #ccc;
   width: 480px;
   height: 480px;
+  clear: both;
+  margin: auto;
+}
+
+.history {
+  clear: both;
 }
 
 .board-row {


### PR DESCRIPTION
Updated the README which now shows how to initialize the `Chess` component.

Basic chessboard without server-side functionality:

```js
import React from 'react';
import ReactDOM from 'react-dom';
import { Chess } from 'redux-chess';

const props = {};

ReactDOM.render(
  <Chess props={props} />,
  document.getElementById('redux-chess')
);
```

Chessboard with server-side functionality such as move validation and so on:

```js
import React from 'react';
import ReactDOM from 'react-dom';
import { Chess } from 'redux-chess';

const props = {
  server: {
    host: '127.0.0.1',
    port: '8080'
  }
};

ReactDOM.render(
  <Chess props={props} />,
  document.getElementById('redux-chess')
);

```